### PR TITLE
Use "type": "wp-cli-package" to designate this as a WP-CLI package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "frozzare/wp-cli-media-restore",
   "description": "Restore media attachments using WP CLI",
-  "type": "command",
+  "type": "wp-cli-package",
   "keywords": ["attachments", "wp-cli", "wordpress"],
   "homepage": "https://github.com/frozzare/wp-cli-media-restore",
   "license": "MIT",


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/issues/2567
